### PR TITLE
Start to add getters and setters to WITSML2 Well (#118)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set (Fesapi_VERSION ${Fesapi_VERSION_MAJOR}.${Fesapi_VERSION_MINOR}.${Fesapi_VER
 
 set (CPP_LIBRARY_NAME FesapiCpp)
 set (CS_LIBRARY_NAME FesapiCs)
+set (SUFFIX_INCLUDES_VERSION TRUE)
 set (UNDER_DEV TRUE)
 if (${UNDER_DEV})
 	set (CPP_LIBRARY_NAME ${CPP_LIBRARY_NAME}UnderDev)
@@ -85,6 +86,10 @@ SET (HDF5_C_LIBRARY_RELEASE HDF5_C_LIBRARY_RELEASE-NOTFOUND CACHE FILEPATH "Path
 IF (NOT EXISTS ${HDF5_C_LIBRARY_RELEASE})
 	MESSAGE(WARNING "The HDF5 library (HDF5_C_LIBRARY_RELEASE variable) does not look to be a valid file. Please modify it.")
 ENDIF ()
+SET (HDF5_C_LIBRARY_DEBUG HDF5_C_LIBRARY_DEBUG-NOTFOUND CACHE FILEPATH "Path to the file which contains the HDF5 C library debug")
+IF (NOT EXISTS ${HDF5_C_LIBRARY_DEBUG})
+	MESSAGE(WARNING "The HDF5 library (HDF5_C_LIBRARY_DEBUG variable) does not look to be a valid file. Please modify it.")
+ENDIF ()
 IF (WIN32)
 	SET (HDF5_BUILT_AS_DYNAMIC_LIB ON CACHE BOOL "Is your HDF5 library built as a dynamic library ?")
 ENDIF (WIN32)
@@ -99,6 +104,11 @@ MARK_AS_ADVANCED(CLEAR ZLIB_LIBRARY_RELEASE)
 IF (NOT EXISTS ${ZLIB_LIBRARY_RELEASE})
 	MESSAGE(WARNING "The zlib library (ZLIB_LIBRARY_RELEASE variable) does not look to be a valid file. Please modify it.")
 ENDIF ()
+MARK_AS_ADVANCED(CLEAR ZLIB_LIBRARY_DEBUG)
+IF (NOT EXISTS ${ZLIB_LIBRARY_DEBUG})
+	MESSAGE(WARNING "The zlib library (ZLIB_LIBRARY_DEBUG variable) does not look to be a valid file. Please modify it.")
+ENDIF ()
+
 
 # Minizip
 SET (MINIZIP_INCLUDE_DIR MINIZIP_INCLUDE_DIR-NOTFOUND CACHE PATH "Path to the directory which contains the minizip header files")
@@ -109,11 +119,20 @@ SET (MINIZIP_LIBRARY_RELEASE MINIZIP_LIBRARY_RELEASE-NOTFOUND CACHE FILEPATH "Pa
 IF (NOT EXISTS ${MINIZIP_LIBRARY_RELEASE})
 	MESSAGE(WARNING "The Minizip library (MINIZIP_LIBRARY_RELEASE variable) does not look to be a valid file. Please modify it.")
 ENDIF ()
+SET (MINIZIP_LIBRARY_DEBUG MINIZIP_LIBRARY_DEBUG-NOTFOUND CACHE FILEPATH "Path to the file which contains the minizip library DEBUG")
+IF (NOT EXISTS ${MINIZIP_LIBRARY_DEBUG})
+	MESSAGE(WARNING "The Minizip library (MINIZIP_LIBRARY_DEBUG variable) does not look to be a valid file. Please modify it.")
+ENDIF ()
+
 
 # Szip (only useful when using static linking to HDF5)
 SET (SZIP_LIBRARY_RELEASE SZIP_LIBRARY_RELEASE-NOTFOUND CACHE FILEPATH "Path to the file which contains the szip library release")
 IF (NOT EXISTS ${SZIP_LIBRARY_RELEASE} AND WIN32 AND NOT ${HDF5_BUILT_AS_DYNAMIC_LIB})
 	MESSAGE(WARNING "The Szip library (SZIP_LIBRARY_RELEASE variable) does not look to be a valid file. Please modify it.")
+ENDIF ()
+SET (SZIP_LIBRARY_DEBUG SZIP_LIBRARY_DEBUG-NOTFOUND CACHE FILEPATH "Path to the file which contains the szip library DEBUG")
+IF (NOT EXISTS ${SZIP_LIBRARY_DEBUG} AND WIN32 AND NOT ${HDF5_BUILT_AS_DYNAMIC_LIB})
+	MESSAGE(WARNING "The Szip library (SZIP_LIBRARY_DEBUG variable) does not look to be a valid file. Please modify it.")
 ENDIF ()
 
 # Uuid

--- a/cmake/AssemblyInfo.cs
+++ b/cmake/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("F2I-CONSULTING")]
 [assembly: AssemblyProduct("FesapiCs")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
+[assembly: AssemblyCopyright("Copyright © 2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/cmake/FesapiJavaExample.java
+++ b/cmake/FesapiJavaExample.java
@@ -53,7 +53,7 @@ public class FesapiJavaExample {
 	 */
 	static {
 		try {
-			System.loadLibrary("${CPP_LIBRARY_NAME}.${Fesapi_VERSION}");
+			System.loadLibrary("${ASSEMBLY_NAME}");
 		}
 		catch (UnsatisfiedLinkError e) {
 			System.out.println("UnsatisfiedLinkError : " + e.toString());

--- a/cmake/fesapiCs.csproj.template
+++ b/cmake/fesapiCs.csproj.template
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>f2i.energisticsStandardsApi</RootNamespace>
-    <AssemblyName>${CS_LIBRARY_NAME}.${Fesapi_VERSION}</AssemblyName>
+    <AssemblyName>${CS_LIBRARY_NAME}</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1931,7 +1931,7 @@ void deserializeStratiColumn(StratigraphicColumn * stratiColumn)
 
 void deserializeSealedSurfaceFramework(const COMMON_NS::EpcDocument & pck)
 {
-	const std::vector<RESQML2_0_1_NS::SealedSurfaceFrameworkRepresentation*> ssfVec = pck.getResqml2_0Objects<RESQML2_0_1_NS::SealedSurfaceFrameworkRepresentation>();
+	const std::vector<RESQML2_0_1_NS::SealedSurfaceFrameworkRepresentation*> ssfVec = pck.getDataObjects<RESQML2_0_1_NS::SealedSurfaceFrameworkRepresentation>();
 
 	for (size_t ssfIndex = 0; ssfIndex < ssfVec.size(); ++ssfIndex) {
 		std::cout << "\tSEALED SURFACE FRAMEWORK" << std::endl;
@@ -2013,7 +2013,7 @@ void deserializeSealedSurfaceFramework(const COMMON_NS::EpcDocument & pck)
 
 void deserializeSealedVolumeFramework(const COMMON_NS::EpcDocument & pck)
 {
-	const std::vector<RESQML2_0_1_NS::SealedVolumeFrameworkRepresentation*> svfVec = pck.getResqml2_0Objects<RESQML2_0_1_NS::SealedVolumeFrameworkRepresentation>();
+	const std::vector<RESQML2_0_1_NS::SealedVolumeFrameworkRepresentation*> svfVec = pck.getDataObjects<RESQML2_0_1_NS::SealedVolumeFrameworkRepresentation>();
 
 	for (size_t svfIndex = 0; svfIndex < svfVec.size(); ++svfIndex) {
 		std::cout << "\tSEALED VOLUME FRAMEWORK" << std::endl;
@@ -3040,7 +3040,7 @@ void deserializePerforations(COMMON_NS::EpcDocument & pck)
 {
 	cout << endl << "PERFORATIONS" << endl;
 
-	WITSML2_0_NS::WellboreCompletion* wellboreCompletion = static_cast<WITSML2_0_NS::WellboreCompletion*>(pck.getDataObjectByUuid("7bda8ecf-2037-4dc7-8c59-db6ca09f2008"));
+	WITSML2_0_NS::WellboreCompletion* wellboreCompletion = pck.getDataObjectByUuid<WITSML2_0_NS::WellboreCompletion>("7bda8ecf-2037-4dc7-8c59-db6ca09f2008");
 	if (wellboreCompletion == nullptr) {
 		return;
 	}
@@ -3966,7 +3966,7 @@ int main()
 	}
 	catch (const std::invalid_argument & Exp)
 	{
-		std::cerr << "Error : " << Exp.what() << ".\n";
+		std::cerr << "Error : " << Exp.what() << std::endl;
 	}
 
 	//cout << "Press enter to continue..." << endl;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,21 +37,66 @@ endif (WIN32)
 
 # Linker instructions
 if (WIN32)
-	target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${MINIZIP_LIBRARY_RELEASE} ${HDF5_C_LIBRARY_RELEASE})
+	if (NOT EXISTS ${MINIZIP_LIBRARY_DEBUG} OR NOT EXISTS ${HDF5_C_LIBRARY_DEBUG})
+		set(CMAKE_CONFIGURATION_TYPES "Release;MinSizeRel;RelWithDebInfo" CACHE STRING "" FORCE)
+	endif ()
+	if (NOT EXISTS ${MINIZIP_LIBRARY_RELEASE} OR NOT EXISTS ${HDF5_C_LIBRARY_RELEASE})
+		set(CMAKE_CONFIGURATION_TYPES "Debug" CACHE STRING "" FORCE)
+	endif ()
+
+	if (EXISTS ${MINIZIP_LIBRARY_RELEASE} AND EXISTS ${MINIZIP_LIBRARY_DEBUG}) 
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE optimized ${MINIZIP_LIBRARY_RELEASE} debug ${MINIZIP_LIBRARY_DEBUG})
+	elseif (EXISTS ${MINIZIP_LIBRARY_RELEASE})
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${MINIZIP_LIBRARY_RELEASE})
+	elseif (EXISTS ${MINIZIP_LIBRARY_DEBUG})
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${MINIZIP_LIBRARY_DEBUG})
+	else ()
+		message(ERROR "No minizip library has been set.")
+	endif ()
+	
+	if (EXISTS ${HDF5_C_LIBRARY_RELEASE} AND EXISTS ${HDF5_C_LIBRARY_DEBUG}) 
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE optimized ${HDF5_C_LIBRARY_RELEASE} debug ${HDF5_C_LIBRARY_DEBUG})
+	elseif (EXISTS ${HDF5_C_LIBRARY_RELEASE})
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${HDF5_C_LIBRARY_RELEASE})
+	elseif (EXISTS ${HDF5_C_LIBRARY_DEBUG})
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${HDF5_C_LIBRARY_DEBUG})
+	else ()
+		message(ERROR "No hdf5 library has been set.")
+	endif ()
+		
 # zlib is linked because it is a dependency of minizip which is usually statically linked to fesapi. If minizip would be dynamically linked from fesapi, zlib could be not present in these linked libraries.
 # zlib is linked because it is a very probable dependency of hdf5 which is sometimes statically linked to fesapi. If hdf5 would be dynamically linked from fesapi (or if hdf5 does not depend at all to zlib), zlib could be not present in these linked libraries.
-	if (EXISTS ${ZLIB_LIBRARY_RELEASE})
+	if (EXISTS ${ZLIB_LIBRARY_RELEASE} AND EXISTS ${ZLIB_LIBRARY_DEBUG}) 
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE optimized ${ZLIB_LIBRARY_RELEASE} debug ${ZLIB_LIBRARY_DEBUG})
+	elseif (EXISTS ${ZLIB_LIBRARY_RELEASE})
 		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${ZLIB_LIBRARY_RELEASE})
+	elseif (EXISTS ${ZLIB_LIBRARY_DEBUG})
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${ZLIB_LIBRARY_DEBUG})
 	endif ()
+	
 # szip is linked because it is a potential dependency of hdf5 which is sometimes statically linked to fesapi. If hdf5 would be dynamically linked from fesapi (or if hdf5 does not depend at all to szip), szip could be not present in these linked libraries.
-	if (EXISTS ${SZIP_LIBRARY_RELEASE})
+	if (EXISTS ${SZIP_LIBRARY_RELEASE} AND EXISTS ${SZIP_LIBRARY_DEBUG}) 
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE optimized ${SZIP_LIBRARY_RELEASE} debug ${SZIP_LIBRARY_DEBUG})
+	elseif (EXISTS ${SZIP_LIBRARY_RELEASE})
 		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${SZIP_LIBRARY_RELEASE})
+	elseif (EXISTS ${SZIP_LIBRARY_DEBUG})
+		target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${SZIP_LIBRARY_DEBUG})
+	endif ()
+	
+	set (ASSEMBLY_NAME ${CPP_LIBRARY_NAME})
+	set (DLL_SUFFIX ".dll")  
+	set (IMPORT_SUFFIX ".lib")
+	if (SUFFIX_INCLUDES_VERSION)
+		set (ASSEMBLY_NAME ${ASSEMBLY_NAME}.${Fesapi_VERSION})
+		set (CS_LIBRARY_NAME ${CS_LIBRARY_NAME}.${Fesapi_VERSION})
+		set (DLL_SUFFIX .${Fesapi_VERSION}${DLL_SUFFIX})  
+		set (IMPORT_SUFFIX .${Fesapi_VERSION}${IMPORT_SUFFIX})
 	endif ()
 	set_target_properties(${CPP_LIBRARY_NAME} PROPERTIES
 		LINK_FLAGS "/INCREMENTAL:NO /OPT:REF"
 		RUNTIME_OUTPUT_DIRECTORY ${FESAPI_BINARY_DIR}
-		SUFFIX ".${Fesapi_VERSION}.dll"
-		IMPORT_SUFFIX ".${Fesapi_VERSION}.lib"
+		SUFFIX ${DLL_SUFFIX}
+		IMPORT_SUFFIX ${IMPORT_SUFFIX}
 		VERSION ${Fesapi_VERSION_MAJOR}.${Fesapi_VERSION_MINOR})
 ELSEIF (UNIX)
 	target_link_libraries (${CPP_LIBRARY_NAME} PRIVATE ${UUID_LIBRARY_RELEASE} ${GSOAP_LIBRARIES} ${MINIZIP_LIBRARY_RELEASE} ${HDF5_C_LIBRARY_RELEASE})

--- a/src/common/EpcDocument.cpp
+++ b/src/common/EpcDocument.cpp
@@ -791,6 +791,12 @@ string EpcDocument::deserialize()
 
 	updateAllRelationships();
 
+	// Validate properties
+	const vector<RESQML2_NS::AbstractProperty*> allprops = getDataObjects<RESQML2_NS::AbstractProperty>();
+	for (size_t propIndex = 0; propIndex < allprops.size(); ++propIndex) {
+		allprops[propIndex]->validate();
+	}
+
 	return result;
 }
 

--- a/src/common/EpcDocument.h
+++ b/src/common/EpcDocument.h
@@ -311,19 +311,25 @@ namespace COMMON_NS
 		std::vector<COMMON_NS::AbstractObject*> getResqml2_0ObjectsByXmlTag(const std::string & xmlTag) const;
 
 		/**
-		* Get RESQML2.0 objects which honor a particular XML tag.
+		* Get all data objects of a particular type indicated by means of the template class.
 		*
-		* @return The vector of RESQML2.0.1 objects in this EPC Document which honor the XML tag
+		* @return The vector of data object in this EPC Document 
 		*/
 		template <class valueType>
-		std::vector<valueType*> getResqml2_0Objects() const
+		std::vector<valueType*> getDataObjects() const
 		{
-			std::vector<COMMON_NS::AbstractObject*> const untypedResult = getResqml2_0ObjectsByXmlTag(valueType::XML_TAG);
-
 			std::vector<valueType*> result;
-			for (size_t i = 0; i < untypedResult.size(); ++i) {
-				result.push_back(static_cast<valueType*>(untypedResult[i]));
+
+#if (defined(_WIN32) && _MSC_VER >= 1600) || defined(__APPLE__)
+			for (std::unordered_map< std::string, COMMON_NS::AbstractObject* >::const_iterator it = dataObjectSet.begin(); it != dataObjectSet.end(); ++it) {
+#else
+			for (std::tr1::unordered_map< std::string, COMMON_NS::AbstractObject* >::const_iterator it = dataObjectSet.begin(); it != dataObjectSet.end(); ++it) {
+#endif
+				if (dynamic_cast<valueType*>(it->second) != nullptr) {
+					result.push_back(static_cast<valueType*>(it->second));
+				}
 			}
+
 			return result;
 		}
 

--- a/src/resqml2/AbstractProperty.cpp
+++ b/src/resqml2/AbstractProperty.cpp
@@ -200,15 +200,9 @@ void AbstractProperty::importRelationshipSetFromEpc(COMMON_NS::EpcDocument* epcD
 			}
 		}
 
-		validatePropertyKindAssociation(pk);
-
 		updateXml = false;
 		setLocalPropertyKind(pk);
 		updateXml = true;
-	}
-	else {
-
-		validatePropertyKindAssociation(getEnergisticsPropertyKind());
 	}
 
 	string uuidHdfProxy = getHdfProxyUuid();
@@ -221,6 +215,11 @@ void AbstractProperty::importRelationshipSetFromEpc(COMMON_NS::EpcDocument* epcD
 		setHdfProxy(hdfProxy);
 		updateXml = true;
 	}
+}
+
+bool AbstractProperty::validate()
+{
+	return isAssociatedToOneStandardEnergisticsPropertyKind() ? validatePropertyKindAssociation(getEnergisticsPropertyKind()) : validatePropertyKindAssociation(getLocalPropertyKind());
 }
 
 void AbstractProperty::setRepresentation(AbstractRepresentation * rep)

--- a/src/resqml2/AbstractProperty.h
+++ b/src/resqml2/AbstractProperty.h
@@ -220,6 +220,11 @@ namespace RESQML2_NS
 		*/
 		virtual bool validatePropertyKindAssociation(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & pk) = 0;
 
+		/**
+		* Check if the associated property kind is allowed for this property.
+		*/
+		bool validate();
+
 	protected:
 
 		void setXmlRepresentation(class AbstractRepresentation * rep);

--- a/src/resqml2/PropertyKind.cpp
+++ b/src/resqml2/PropertyKind.cpp
@@ -181,4 +181,3 @@ void PropertyKind::importRelationshipSetFromEpc(COMMON_NS::EpcDocument* epcDoc)
 	}
 	parentPk->childPropertyKind.push_back(this);
 }
-

--- a/src/resqml2/PropertyKind.h
+++ b/src/resqml2/PropertyKind.h
@@ -120,6 +120,11 @@ namespace RESQML2_NS
 		*/
 		virtual bool isAbstract() const = 0;
 
+		/**
+		* Check if this property kind is partial or if one of its parent is partial.
+		*/
+		virtual bool isParentPartial() const = 0;
+
 	protected:
 		virtual void setXmlParentPropertyKind(PropertyKind* parentPropertyKind) = 0;
 

--- a/src/resqml2_0_1/CategoricalProperty.cpp
+++ b/src/resqml2_0_1/CategoricalProperty.cpp
@@ -190,6 +190,10 @@ bool CategoricalProperty::validatePropertyKindAssociation(RESQML2_NS::PropertyKi
 			return false;
 		}
 		if (epcDocument->getPropertyKindMapper() != nullptr) {
+			if (pk->isParentPartial()) {
+				epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the categorical property " + getUuid() + " is right because one if its parent property kind is abstract.");
+				return true;
+			}
 			if (!pk->isChildOf(resqml2__ResqmlPropertyKind__categorical)) {
 				if (!pk->isChildOf(resqml2__ResqmlPropertyKind__discrete)) {
 					epcDocument->addWarning("The categorical property " + getUuid() + " cannot be associated to a local property kind " + pk->getUuid() + " which does not derive from the discrete or categorical standard property kind. This property will be assumed to be a partial one.");
@@ -204,6 +208,9 @@ bool CategoricalProperty::validatePropertyKindAssociation(RESQML2_NS::PropertyKi
 		else {
 			epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the categorical property " + getUuid() + " is right because no property kind mapping files have been loaded.");
 		}
+	}
+	else {
+		epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the categorical property " + getUuid() + " is right because it is abstract.");
 	}
 
 	return true;

--- a/src/resqml2_0_1/CommentProperty.cpp
+++ b/src/resqml2_0_1/CommentProperty.cpp
@@ -204,6 +204,10 @@ bool CommentProperty::validatePropertyKindAssociation(RESQML2_NS::PropertyKind* 
 			return false;
 		}
 		if (epcDocument->getPropertyKindMapper() != nullptr) {
+			if (pk->isParentPartial()) {
+				epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the comment property " + getUuid() + " is right because one if its parent property kind is abstract.");
+				return true;
+			}
 			if (pk->isChildOf(resqml2__ResqmlPropertyKind__continuous) || pk->isChildOf(resqml2__ResqmlPropertyKind__discrete) || pk->isChildOf(resqml2__ResqmlPropertyKind__categorical)) {
 				epcDocument->addWarning("The comment property " + getUuid() + " cannot be associated to a local property kind " + pk->getUuid() + " which is either a continuous, discrete or categorical standard property kind. This property will be assumed to be a partial one.");
 				changeToPartialObject();
@@ -211,8 +215,11 @@ bool CommentProperty::validatePropertyKindAssociation(RESQML2_NS::PropertyKind* 
 			}
 		}
 		else {
-			epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the continuous property " + getUuid() + " is right because no property kind mapping files have been loaded.");
+			epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the comment property " + getUuid() + " is right because no property kind mapping files have been loaded.");
 		}
+	}
+	else {
+		epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the comment property " + getUuid() + " is right because it is abstract.");
 	}
 
 	return true;

--- a/src/resqml2_0_1/ContinuousProperty.cpp
+++ b/src/resqml2_0_1/ContinuousProperty.cpp
@@ -442,6 +442,10 @@ bool ContinuousProperty::validatePropertyKindAssociation(RESQML2_NS::PropertyKin
 			return false;
 		}
 		if (epcDocument->getPropertyKindMapper() != nullptr) {
+			if (pk->isParentPartial()) {
+				epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the continuous property " + getUuid() + " is right because one if its parent property kind is abstract.");
+				return true;
+			}
 			if (!pk->isChildOf(resqml2__ResqmlPropertyKind__continuous)) {
 				epcDocument->addWarning("The continuous property " + getUuid() + " cannot be associated to a local property kind " + pk->getUuid() + " which does not derive from the continuous standard property kind. This property will be assumed to be a partial one.");
 				changeToPartialObject();
@@ -451,6 +455,9 @@ bool ContinuousProperty::validatePropertyKindAssociation(RESQML2_NS::PropertyKin
 		else {
 			epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the continuous property " + getUuid() + " is right because no property kind mapping files have been loaded.");
 		}
+	}
+	else {
+		epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the continuous property " + getUuid() + " is right because it is abstract.");
 	}
 
 	return true;

--- a/src/resqml2_0_1/DiscreteProperty.cpp
+++ b/src/resqml2_0_1/DiscreteProperty.cpp
@@ -421,6 +421,10 @@ bool DiscreteProperty::validatePropertyKindAssociation(RESQML2_NS::PropertyKind*
 			return false;
 		}
 		if (epcDocument->getPropertyKindMapper() != nullptr) {
+			if (pk->isParentPartial()) {
+				epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the discrete property " + getUuid() + " is right because one if its parent property kind is abstract.");
+				return true;
+			}
 			if (!pk->isChildOf(resqml2__ResqmlPropertyKind__discrete)) {
 				if (!pk->isChildOf(resqml2__ResqmlPropertyKind__categorical)) {
 					epcDocument->addWarning("The discrete property " + getUuid() + " cannot be associated to a local property kind " + pk->getUuid() + " which does not derive from the discrete or categorical standard property kind. This property will be assumed to be a partial one.");
@@ -433,8 +437,11 @@ bool DiscreteProperty::validatePropertyKindAssociation(RESQML2_NS::PropertyKind*
 			}
 		}
 		else {
-			epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the categorical property " + getUuid() + " is right because no property kind mapping files have been loaded.");
+			epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the discrete property " + getUuid() + " is right because no property kind mapping files have been loaded.");
 		}
+	}
+	else {
+		epcDocument->addWarning("Cannot verify if the local property kind " + pk->getUuid() + " of the discrete property " + getUuid() + " is right because it is abstract.");
 	}
 
 	return true;

--- a/src/resqml2_0_1/PropertyKind.cpp
+++ b/src/resqml2_0_1/PropertyKind.cpp
@@ -103,10 +103,14 @@ void PropertyKind::setXmlParentPropertyKind(RESQML2_NS::PropertyKind* parentProp
 
 bool PropertyKind::isChildOf(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind standardPropKind) const
 {
+	if (isPartial()) {
+		throw std::invalid_argument("The property kind " + getUuid() + " is partial, we cannot consequently get its parents.");
+	}
+
 	if (!isParentAnEnergisticsPropertyKind()) {
 		return getParentLocalPropertyKind()->isChildOf(standardPropKind);
 	}
-	else{
+	else {
 		if (getParentEnergisticsPropertyKind() == standardPropKind) {
 			return true;
 		}
@@ -124,3 +128,18 @@ bool PropertyKind::isAbstract() const
 	return getSpecializedGsoapProxy()->IsAbstract;
 }
 
+bool PropertyKind::isParentPartial() const
+{
+	if (isPartial()) { return true; }
+
+	if (isParentAnEnergisticsPropertyKind()) {
+		return false;
+	}
+
+	RESQML2_NS::PropertyKind* parentPk = getParentLocalPropertyKind();
+	while (!parentPk->isPartial() && !parentPk->isParentAnEnergisticsPropertyKind()) {
+		parentPk = parentPk->getParentLocalPropertyKind();
+	}
+
+	return parentPk->isPartial();
+}

--- a/src/resqml2_0_1/PropertyKind.h
+++ b/src/resqml2_0_1/PropertyKind.h
@@ -97,6 +97,8 @@ namespace RESQML2_0_1_NS
 
 		bool isAbstract() const;
 
+		bool isParentPartial() const;
+
 	protected:
 		void setXmlParentPropertyKind(RESQML2_NS::PropertyKind* parentPropertyKind);
 		

--- a/src/tools/TimeTools.cpp
+++ b/src/tools/TimeTools.cpp
@@ -18,14 +18,13 @@ under the License.
 -----------------------------------------------------------------------*/
 #include "tools/TimeTools.h"
 
-#include <cmath>
 #include <ctime>
 #include <sstream>
 #include <iomanip>
 
 using namespace std;
-
-std::string timeTools::convertMicrosecondUnixTimestampToIso(const long long & ts)
+/*
+std::string timeTools::convertMicrosecondUnixTimestampToIso(long long ts)
 {
 	// microsecond part
 	long long onlyMicrosec = 0;
@@ -45,8 +44,8 @@ std::string timeTools::convertMicrosecondUnixTimestampToIso(const long long & ts
 
 	return oss.str();
 }
-
-std::string timeTools::convertUnixTimestampToIso(const time_t & ts)
+*/
+std::string timeTools::convertUnixTimestampToIso(time_t ts)
 {
 	char buf[20]; // 19 for the string below +1 for the terminating char
 	strftime(buf, 20, "%Y-%m-%dT%H:%M:%S", gmtime(&ts));

--- a/src/tools/TimeTools.h
+++ b/src/tools/TimeTools.h
@@ -18,6 +18,7 @@ under the License.
 -----------------------------------------------------------------------*/
 #pragma once
 
+#include <ctime>
 #include <string>
 
 namespace timeTools
@@ -25,12 +26,14 @@ namespace timeTools
 	/**
 	* Convert an Unix timestamp which is given in microseconds into a date in ISO format.
 	*/
-	std::string convertMicrosecondUnixTimestampToIso(const long long & ts);
+	// No more used because DAS support has been removed
+	// Disabled because it needs to include <cmath> which creates a conflict with gsoap 2.8.81 : see https://github.com/F2I-Consulting/fesapi/issues/90
+	//std::string convertMicrosecondUnixTimestampToIso(long long ts);
 
 	/**
 	* Convert an Unix timestamp which is given in seconds into a date in ISO format.
 	*/
-	std::string convertUnixTimestampToIso(const time_t & ts);
+	std::string convertUnixTimestampToIso(time_t ts);
 
 	/**
 	* Converts a UTC time (given in seconds) represented by a string to a UTC time represented by a time_t type.

--- a/src/witsml2_0/Well.cpp
+++ b/src/witsml2_0/Well.cpp
@@ -21,6 +21,8 @@ under the License.
 #include <stdexcept>
 #include <sstream>
 
+#include "tools/TimeTools.h"
+
 using namespace std;
 using namespace WITSML2_0_NS;
 using namespace gsoap_eml2_1;
@@ -33,7 +35,9 @@ Well::Well(soap* soapContext,
 			const std::string & guid,
 			const std::string & title):resqmlWellboreFeature(nullptr)
 {
-	if (soapContext == nullptr) throw invalid_argument("A soap context must exist.");
+	if (soapContext == nullptr) {
+		throw invalid_argument("A soap context must exist.");
+	}
 
 	gsoapProxy2_1 = soap_new_witsml2__Well(soapContext, 1);
 
@@ -49,7 +53,9 @@ Well::Well(soap* soapContext,
 		witsml2__WellDirection directionWell
 	):resqmlWellboreFeature(nullptr)
 {
-	if (soapContext == nullptr) throw invalid_argument("A soap context must exist.");
+	if (soapContext == nullptr) {
+		throw invalid_argument("A soap context must exist.");
+	}
 
 	gsoapProxy2_1 = soap_new_witsml2__Well(soapContext, 1);
 
@@ -67,16 +73,131 @@ Well::Well(soap* soapContext,
 	*well->DirectionWell = directionWell;
 }
 
-void Well::setOperator(const string & operator_) 
-{
-	if (operator_.empty()) throw invalid_argument("You must set a non empty operator.");
-
-	witsml2__Well* well = static_cast<witsml2__Well*>(gsoapProxy2_1);
-
-	if (well->Operator == nullptr) {
-		well->Operator = soap_new_std__string(gsoapProxy2_1->soap, 1);
+void Well::setString(std::string* & strToBeSet, const std::string & strToSet) {
+	if (strToSet.empty()) {
+		throw invalid_argument("The value to set cannot be empty.");
 	}
-	well->Operator->assign(operator_);
+
+	if (strToBeSet == nullptr) {
+		strToBeSet = soap_new_std__string(gsoapProxy2_1->soap, 1);
+	}
+	strToBeSet->assign(strToSet);
+}
+
+#define GETTER_PRESENCE_ATTRIBUTE_IMPL(attributeName) bool Well::has##attributeName() const { return static_cast<witsml2__Well*>(gsoapProxy2_1)->attributeName != nullptr; }
+
+#define GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(attributeName)\
+	void Well::set##attributeName(const std::string & attributeName) { setString(static_cast<witsml2__Well*>(gsoapProxy2_1)->attributeName, attributeName); }\
+	GETTER_PRESENCE_ATTRIBUTE_IMPL(attributeName)\
+	std::string Well::get##attributeName() const {\
+		if (!has##attributeName()) { throw invalid_argument("The string attribute to get does not exist."); }\
+		return *static_cast<witsml2__Well*>(gsoapProxy2_1)->attributeName;\
+	}
+
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(NameLegal)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(NumLicense)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(NumGovt)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(Field)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(Country)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(State)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(County)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(Region)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(District)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(Block)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(Operator)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(OperatorDiv)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(OriginalOperator)
+GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE_IMPL(NumAPI)
+
+#define GETTER_AND_SETTER_WELL_LENGTH_MEASURE_ATTRIBUTE_IMPL(attributeName, constructor)\
+	void Well::set##attributeName(double value, gsoap_eml2_1::eml21__LengthUom uom) {\
+		if (value != value) { throw invalid_argument("You cannot set an undefined water depth"); }\
+		witsml2__Well* well = static_cast<witsml2__Well*>(gsoapProxy2_1);\
+		if (well->attributeName == nullptr) { well->attributeName = constructor; }\
+		well->attributeName->__item = value;\
+		well->attributeName->uom = uom;\
+	}\
+	GETTER_PRESENCE_ATTRIBUTE_IMPL(attributeName)\
+	double Well::get##attributeName##Value() const {\
+		if (!has##attributeName()) { throw invalid_argument("The length measure attribute to get does not exist."); }\
+		return static_cast<witsml2__Well*>(gsoapProxy2_1)->attributeName->__item;\
+	}\
+	gsoap_eml2_1::eml21__LengthUom Well::get##attributeName##Uom() const {\
+		if (!has##attributeName()) { throw invalid_argument("The length measure attribute to get does not exist."); }\
+		return static_cast<witsml2__Well*>(gsoapProxy2_1)->attributeName->uom;\
+	}\
+
+GETTER_AND_SETTER_WELL_LENGTH_MEASURE_ATTRIBUTE_IMPL(WaterDepth, soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap, 1))
+GETTER_AND_SETTER_WELL_LENGTH_MEASURE_ATTRIBUTE_IMPL(GroundElevation, soap_new_witsml2__WellElevationCoord(gsoapProxy2_1->soap, 1))
+
+#define GETTER_AND_SETTER_WELL_TIMESTAMP_ATTRIBUTE_IMPL(attributeName)\
+	void Well::set##attributeName(unsigned int attributeName) { setString(static_cast<witsml2__Well*>(gsoapProxy2_1)->attributeName, timeTools::convertUnixTimestampToIso(attributeName)); }\
+	GETTER_PRESENCE_ATTRIBUTE_IMPL(attributeName)\
+	unsigned int Well::get##attributeName() const {\
+		if (!has##attributeName()) { throw invalid_argument("The string attribute to get does not exist."); }\
+		return timeTools::convertIsoToUnixTimestamp(*static_cast<witsml2__Well*>(gsoapProxy2_1)->attributeName);\
+	}
+
+GETTER_AND_SETTER_WELL_TIMESTAMP_ATTRIBUTE_IMPL(DTimLicense)
+GETTER_AND_SETTER_WELL_TIMESTAMP_ATTRIBUTE_IMPL(DTimSpud)
+GETTER_AND_SETTER_WELL_TIMESTAMP_ATTRIBUTE_IMPL(DTimPa)
+
+void Well::setTimeZone(bool direction, unsigned short hours, unsigned short minutes)
+{
+	if (hours > 23) { throw invalid_argument("You cannot set a time zone superior to 23 hours"); }
+	if (minutes > 59) { throw invalid_argument("You cannot set a time zone superior to 59 minutes"); }
+	witsml2__Well* well = static_cast<witsml2__Well*>(gsoapProxy2_1);
+	if (well->TimeZone == nullptr) { well->TimeZone = soap_new_eml21__TimeZone(gsoapProxy2_1->soap, 1); }
+
+	if (hours == 00 && minutes == 0) {
+		well->TimeZone->assign("Z");
+		return;
+	}
+
+	std::ostringstream oss;
+	if (direction) {
+		oss << "+";
+	}
+	else {
+		oss << "-";
+	}
+
+	if (hours < 10) {
+		oss << "0";
+	}
+	oss << hours << ":";
+
+	if (minutes < 10) {
+		oss << "0";
+	}
+	oss << minutes;
+
+	well->TimeZone->assign(oss.str());
+}
+GETTER_PRESENCE_ATTRIBUTE_IMPL(TimeZone)
+bool Well::getTimeZoneDirection() const {
+	if (!hasTimeZone()) { throw invalid_argument("The  attribute to get does not exist."); }
+	return static_cast<witsml2__Well*>(gsoapProxy2_1)->TimeZone->at(0) != '-';
+}
+unsigned short Well::getTimeZoneHours() const {
+	if (!hasTimeZone()) { throw invalid_argument("The  attribute to get does not exist."); }
+	if (static_cast<witsml2__Well*>(gsoapProxy2_1)->TimeZone->size() == 1) { return 0; }
+	if (static_cast<witsml2__Well*>(gsoapProxy2_1)->TimeZone->size() != 6) { throw invalid_argument("The time zone does not looks to conform to the XSD standard."); }
+
+	istringstream iss(static_cast<witsml2__Well*>(gsoapProxy2_1)->TimeZone->substr(1,2));
+	unsigned short result;
+	iss >> result;
+	return result;
+}
+unsigned short Well::getTimeZoneMinutes() const {
+	if (!hasTimeZone()) { throw invalid_argument("The  attribute to get does not exist."); }
+	if (static_cast<witsml2__Well*>(gsoapProxy2_1)->TimeZone->size() == 1) { return 0; }
+	if (static_cast<witsml2__Well*>(gsoapProxy2_1)->TimeZone->size() != 6) { throw invalid_argument("The time zone does not looks to conform to the XSD standard."); }
+
+	istringstream iss(static_cast<witsml2__Well*>(gsoapProxy2_1)->TimeZone->substr(4, 2));
+	unsigned short result;
+	iss >> result;
+	return result;
 }
 
 double Well::getLocationProjectedX(unsigned int locationIndex)
@@ -87,7 +208,7 @@ double Well::getLocationProjectedX(unsigned int locationIndex)
 		throw range_error("The well location index is out of range.");
 	}
 	if (well->WellLocation[locationIndex]->soap_type() != SOAP_TYPE_gsoap_eml2_1_witsml2__ProjectedWellLocation){
-		throw range_error("The well location is not a projected one.");
+		throw invalid_argument("The well location is not a projected one.");
 	}
 
 	return static_cast<witsml2__ProjectedWellLocation*>(well->WellLocation[locationIndex])->Coordinate1;
@@ -101,7 +222,7 @@ double Well::getLocationProjectedY(unsigned int locationIndex)
 		throw range_error("The well location index is out of range.");
 	}
 	if (well->WellLocation[locationIndex]->soap_type() != SOAP_TYPE_gsoap_eml2_1_witsml2__ProjectedWellLocation){
-		throw range_error("The well location is not a projected one.");
+		throw invalid_argument("The well location is not a projected one.");
 	}
 
 	return static_cast<witsml2__ProjectedWellLocation*>(well->WellLocation[locationIndex])->Coordinate2;
@@ -208,3 +329,18 @@ vector<Relationship> Well::getAllEpcRelationships() const
 
 void Well::importRelationshipSetFromEpc(COMMON_NS::EpcDocument*)
 {}
+
+RESQML2_0_1_NS::WellboreFeature* Well::getResqmlWellboreFeature() const
+{
+	return resqmlWellboreFeature;
+}
+
+const std::vector<Wellbore*>& Well::getWellbores() const
+{
+	return wellboreSet;
+}
+
+const std::vector<WellCompletion*>& Well::getWellcompletions() const
+{
+	return wellCompletionSet;
+}

--- a/src/witsml2_0/Well.h
+++ b/src/witsml2_0/Well.h
@@ -22,10 +22,30 @@ under the License.
 #include "witsml2_0/Wellbore.h"
 #include "witsml2_0/WellCompletion.h"
 
+#define GETTER_PRESENCE_ATTRIBUTE(attributeName) DLL_IMPORT_OR_EXPORT bool has##attributeName() const;
+
+#define GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(attributeName)\
+	DLL_IMPORT_OR_EXPORT void set##attributeName(const std::string & attributeName);\
+	GETTER_PRESENCE_ATTRIBUTE(attributeName)\
+	DLL_IMPORT_OR_EXPORT std::string get##attributeName() const;
+
+#define GETTER_AND_SETTER_WELL_UINT_ATTRIBUTE(attributeName)\
+	DLL_IMPORT_OR_EXPORT void set##attributeName(unsigned int attributeName);\
+	GETTER_PRESENCE_ATTRIBUTE(attributeName)\
+	DLL_IMPORT_OR_EXPORT unsigned int get##attributeName() const;
+
+#define GETTER_AND_SETTER_WELL_LENGTH_MEASURE_ATTRIBUTE(attributeName)\
+	DLL_IMPORT_OR_EXPORT void set##attributeName(double value, gsoap_eml2_1::eml21__LengthUom uom);\
+	GETTER_PRESENCE_ATTRIBUTE(attributeName)\
+	DLL_IMPORT_OR_EXPORT double get##attributeName##Value() const;\
+	DLL_IMPORT_OR_EXPORT gsoap_eml2_1::eml21__LengthUom get##attributeName##Uom() const;
+
 namespace WITSML2_0_NS
 {
-	class DLL_IMPORT_OR_EXPORT Well : public WITSML2_0_NS::AbstractObject
+	class Well : public WITSML2_0_NS::AbstractObject
 	{
+	private:
+		void setString(std::string* & strToBeSet, const std::string & strToSet);
 	public:
 		/**
 		* Creates an instance of this class in a gsoap context.
@@ -54,20 +74,70 @@ namespace WITSML2_0_NS
 		*/
 		~Well() {}
 
-		void setOperator(const std::string & operator_);
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(NameLegal)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(NumLicense)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(NumGovt)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(Field)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(Country)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(State)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(County)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(Region)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(District)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(Block)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(Operator)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(OperatorDiv)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(OriginalOperator)
+		GETTER_AND_SETTER_WELL_STRING64_ATTRIBUTE(NumAPI)
 
-		double getLocationProjectedX(unsigned int locationIndex);
-		double getLocationProjectedY(unsigned int locationIndex);
+		GETTER_AND_SETTER_WELL_LENGTH_MEASURE_ATTRIBUTE(WaterDepth)
+		GETTER_AND_SETTER_WELL_LENGTH_MEASURE_ATTRIBUTE(GroundElevation)
 
-		void pushBackLocation(
+		GETTER_AND_SETTER_WELL_UINT_ATTRIBUTE(DTimLicense)
+		GETTER_AND_SETTER_WELL_UINT_ATTRIBUTE(DTimSpud)
+		GETTER_AND_SETTER_WELL_UINT_ATTRIBUTE(DTimPa)
+
+		/**
+		* Set the time zone in which the well is located. It is the deviation in hours and minutes from UTC. This should be the normal time zone at the well and not a seasonally-adjusted value, such as daylight savings time
+		*
+		* @param direction	True means the time zone is a positive offset from UTC, false means the time zone is a negative offset from UTC
+		* @param hours		the deviation hours from UTC
+		* @param minutes	the deviation minutes from UTC
+		*/
+		DLL_IMPORT_OR_EXPORT void setTimeZone(bool direction, unsigned short hours, unsigned short minutes = 0);
+		GETTER_PRESENCE_ATTRIBUTE(TimeZone)
+		/**
+		* Get the time zone direction in which the well is located.
+		*
+		* @return True means the time zone is a positive offset from UTC, false means the time zone is a negative offset from UTC. If the time zone is Z then an arbitrary '+' is returned.
+		*/
+		DLL_IMPORT_OR_EXPORT bool getTimeZoneDirection() const;
+		/**
+		* Get the time zone hour(s) in which the well is located.
+		* Must be used with getTimeZoneDirection and getTimeZoneMinute() to have the complete time zone.
+		*
+		* @return the deviation hour(s) from UTC
+		*/
+		DLL_IMPORT_OR_EXPORT unsigned short getTimeZoneHours() const;
+		/**
+		* Get the time zone minute(s) in which the well is located.
+		* Must be used with getTimeZoneDirection and getTimeZoneHour() to have the complete time zone.
+		*
+		* @return the deviation minute(s) from UTC
+		*/
+		DLL_IMPORT_OR_EXPORT unsigned short getTimeZoneMinutes() const;
+
+		DLL_IMPORT_OR_EXPORT double getLocationProjectedX(unsigned int locationIndex);
+		DLL_IMPORT_OR_EXPORT double getLocationProjectedY(unsigned int locationIndex);
+
+		DLL_IMPORT_OR_EXPORT void pushBackLocation(
 			const std::string & guid,
 			double projectedX,
 			double projectedY,
 			unsigned int projectedCrsEpsgCode);
 
-		unsigned int geLocationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int geLocationCount() const;
 		
-		void pushBackDatum(
+		DLL_IMPORT_OR_EXPORT void pushBackDatum(
 			const std::string & guid, 
 			const std::string & title,
 			gsoap_eml2_1::eml21__WellboreDatumReference code,
@@ -76,20 +146,20 @@ namespace WITSML2_0_NS
 			double elevation,
 			unsigned int verticalCrsEpsgCode);
 
-		unsigned int getDatumCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getDatumCount() const;
 		
 		void importRelationshipSetFromEpc(COMMON_NS::EpcDocument* epcDoc);
 
 		std::vector<epc::Relationship> getAllEpcRelationships() const;
 
-		RESQML2_0_1_NS::WellboreFeature* getResqmlWellboreFeature() const { return resqmlWellboreFeature; }
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreFeature* getResqmlWellboreFeature() const;
 
-		const std::vector<Wellbore*>& getWellbores() const { return wellboreSet; }
+		DLL_IMPORT_OR_EXPORT const std::vector<Wellbore*>& getWellbores() const;
 
-		const std::vector<WellCompletion*>& getWellcompletions() const { return wellCompletionSet; }
+		DLL_IMPORT_OR_EXPORT const std::vector<WellCompletion*>& getWellcompletions() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	protected:
 


### PR DESCRIPTION
- Allow to build a DLL without versions in the assembly name
- Allow to automatically switch libraries depending on Debug or Release builds (Visual Studio).
- Rename EpcDcoument::getResqml2_0Objects into EpcDcoument::getDataObjects in order to get WITSML objects as well.
- Fix #117 : Bug when a parent property kind is a partial one
- Remove cmath inclusion in order to avoid some potential isnan and isinf C and C++ method conflicts.

(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …
